### PR TITLE
fix building on recent Raspbian version (missing header)

### DIFF
--- a/mcp251x.c
+++ b/mcp251x.c
@@ -57,7 +57,7 @@
 #include <linux/can/core.h>
 #include <linux/can/dev.h>
 #include <linux/can/led.h>
-#include <linux/can/platform/mcp251x.h>
+#include "mcp251x.h"
 #include <linux/clk.h>
 #include <linux/completion.h>
 #include <linux/delay.h>

--- a/mcp251x.h
+++ b/mcp251x.h
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#ifndef _CAN_PLATFORM_MCP251X_H
+#define _CAN_PLATFORM_MCP251X_H
+/*
+ *
+ * CAN bus driver for Microchip 251x CAN Controller with SPI Interface
+ *
+ */
+#include <linux/spi/spi.h>
+/*
+ * struct mcp251x_platform_data - MCP251X SPI CAN controller platform data
+ * @oscillator_frequency:       - oscillator frequency in Hz
+ */
+struct mcp251x_platform_data {
+	unsigned long oscillator_frequency;
+};
+#endif /* !_CAN_PLATFORM_MCP251X_H */


### PR DESCRIPTION
This is small fix to be able to build on recent Raspbian OS, header file is missing, so I included it locally.
Tested, works on RPI4 B.